### PR TITLE
update RVM list for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 
 
 script: bundle exec rspec
-


### PR DESCRIPTION
This removes Ruby 2.1 and adds 2.4, 2.5, and 2.6 to the Travis runner config.

Also bumps the versions to the latest for each minor release.